### PR TITLE
Customize .env file name via environment variable REACT_APP_DOTENV_CONFIG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ set REACT_APP_COLOR=navy&& set REACT_APP_MAIN_TEXT=Navy Background&& npx react-i
 
 `.env` files are supported. `react-inject-env` will automatically detect environment variables in your `.env` file located in your root folder.
 
+If you want to customize the `.env` file name, you can define the file name in environment variable `REACT_APP_DOTENV_CONFIG_PATH`.
+
 Note: Environment variables passed in through the command line will take precedence over `.env` variables.
 
 ## Typescript

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -17,7 +17,8 @@ export function retrieveReactEnvCfg(): Record<string, string> {
 
 export function retrieveDotEnvCfg(): Record<string, string> {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const env = require('dotenv').config().parsed ?? {}
+  const path = process.env.REACT_APP_DOTENV_CONFIG_PATH ?? '.env';
+  const env = require('dotenv').config({path: path}).parsed ?? {}
 
   const keys = Object.keys(env)
   const reactKeys = keys.filter(key => {


### PR DESCRIPTION
Currently, the module can customize the output file path and name. But it lacks the ability to customize the input `.env` file name.

This pull request added the support of environment variable `REACT_APP_DOTENV_CONFIG_PATH`, if it is defined, the `.config()` method will use its value to configure `dotenv`, otherwise, default value `.env` will be used.

Usage:

```
REACT_APP_DOTENV_CONFIG_PATH=.env.prod npx react-inject-env set -d env -n env.prod.js
```