### PR TITLE
feat: added vite prefix support

### DIFF
--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -2,5 +2,6 @@ export const Cfg = {
   NAME: 'react-inject-env',
 
   PREFIX: 'REACT_APP_',
+  VITE_PREFIX: 'VITE_',
   PLACEHOLDER_2: 'ReactInjectEnv_'
 } as const

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -21,7 +21,7 @@ export function retrieveDotEnvCfg(): Record<string, string> {
 
   const keys = Object.keys(env)
   const reactKeys = keys.filter(key => {
-    return key.startsWith(Cfg.PREFIX) || key === 'PUBLIC_URL'
+    return key.startsWith(Cfg.PREFIX) || key.startsWith(Cfg.VITE_PREFIX) || key === 'PUBLIC_URL'
   })
 
   const envCfg: Record<string, string> = {}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -4,7 +4,7 @@ export function retrieveReactEnvCfg(): Record<string, string> {
   const env = process.env
   const keys = Object.keys(env)
   const reactKeys = keys.filter(key => {
-    return key.startsWith(Cfg.PREFIX) || key === 'PUBLIC_URL'
+    return key.startsWith(Cfg.PREFIX) || key.startsWith(Cfg.VITE_PREFIX) || key === 'PUBLIC_URL'
   })
 
   const envCfg: Record<string, string> = {}


### PR DESCRIPTION
Package at the moment pulls all env vars starting with `REACT_APP_`. This PR adds support for Vite projects which prefixes `VITE_` instead for environment variables. 